### PR TITLE
change cover length to 1024 bytes

### DIFF
--- a/config/mysql_db_init.sql
+++ b/config/mysql_db_init.sql
@@ -34,7 +34,7 @@ CREATE TABLE books (
     year VARCHAR(4) NOT NULL,
     language_id INTEGER NOT NULL,
     plot VARCHAR(10000) NOT NULL,
-    cover VARCHAR(64),
+    cover VARCHAR(1024),
     updated BIGINT NOT NULL DEFAULT 0,
     FOREIGN KEY (language_id) REFERENCES languages (id) ON DELETE CASCADE
 );


### PR DESCRIPTION
Without it I constantly got the error:

```
2022/07/11 12:59:44 server on http://localhost:8085 is listening...
2022/07/11 12:59:44 new aquisitions scanning started...
2022/07/11 12:59:47 Error 1406: Data too long for column 'cover' at row 1
panic: Error 1406: Data too long for column 'cover' at row 1

goroutine 3 [running]:
log.Panic({0xc0000b7b70?, 0x82a1e8?, 0xc00009e000?})
	/usr/local/go/src/log/log.go:385 +0x65
github.com/vinser/flibgo/pkg/database.(*DB).NewBook(0xc0000ac1f0, 0xc0000b7eb0)
	/flibgo/pkg/database/database.go:45 +0x32b
github.com/vinser/flibgo/pkg/stock.(*Handler).processZip(0xc00024c420, {0xc0000640f0, 0x22})
	/flibgo/pkg/stock/stock.go:225 +0xe8a
created by github.com/vinser/flibgo/pkg/stock.(*Handler).ScanDir
	/flibgo/pkg/stock/stock.go:90 +0x78a
exit status 2
```

Maybe 1024 is too long for covers, but with this length it at least works.